### PR TITLE
increase test coverage

### DIFF
--- a/t/simple.t
+++ b/t/simple.t
@@ -14,12 +14,27 @@ sub tester {
 
 package main;
 
-use Test::Most tests => 1;
+use Test::Most tests => 6;
 
 my $t;
 lives_ok(sub {
    $t = Dummy::Test->new();
    $t->tester();
 }, 'MetaCPAN interface is up');
+
+can_ok(
+   $t,
+   qw/
+      mcpan
+      mcpan_ua
+      mcpan_mechua
+      mcpan_cache
+   /
+);
+
+isa_ok( $t->mcpan,'MetaCPAN::API' );
+isa_ok( $t->mcpan_ua,'HTTP::Tiny::Mech' );
+isa_ok( $t->mcpan_mechua,'WWW::Mechanize::Cached::GZIP' );
+isa_ok( $t->mcpan_cache,'CHI' );
 
 diag $t->mcpan_mechua->agent;


### PR DESCRIPTION
I have been given this module as my March CPAN-PRC distribution. I've tried to look at #2 but the module will neither build or test cleanly. It seems to be utterly broken against current versions of its dependencies (or their dependencies, or their...) so i've just added a few tests to the `t/simple.t` test that _should_ pass if i could get this to build.

```
/Volumes/code_partition/Dist-Zilla-Role-MetaCPANInterfacer > dzil test
[Bootstrap::lib] Bootstrapping lib
Detected current environment to be in "author mode" but couldn't load all
modules. Missing (author) modules were:

  autovivification

You should install these modules via CPAN, but these modules are not
required by your users (unless you add them to your META file).
Global symbol "$VERSION" requires explicit package name at lib/Dist/Zilla/Role/MetaCPANInterfacer.pm line 81, <GEN0> line 9.
Compilation failed in require at /Users/leejohnson/lib/perl5/site_perl/5.18.1/Module/Runtime.pm line 317, <GEN0> line 9.
Compilation failed in require at /Users/leejohnson/lib/perl5/site_perl/5.18.1/Module/Runtime.pm line 317, <GEN0> line 9.
Compilation failed in require at /Users/leejohnson/lib/perl5/site_perl/5.18.1/Module/Runtime.pm line 317, <GEN0> line 9. at /Users/leejohnson/lib/perl5/site_perl/5.18.1/darwin-2level/Class/MOP/Method/Wrapped.pm line 158.
```

perl:

```
/Volumes/code_partition/Dist-Zilla-Role-MetaCPANInterfacer > perl -V | head -n11
Summary of my perl5 (revision 5 version 18 subversion 1) configuration:

  Platform:
    osname=darwin, osvers=12.4.0, archname=darwin-2level
    uname='darwin lees-macbook-pro.local 12.4.0 darwin kernel version 12.4.0: wed may 1 17:57:12 pdt 2013; root:xnu-2050.24.15~1release_x86_64 x86_64 '
    config_args='-Dprefix=/Users/leejohnson -d -e'
    hint=recommended, useposix=true, d_sigaction=define
    useithreads=undef, usemultiplicity=undef
    useperlio=define, d_sfio=undef, uselargefiles=define, usesocks=undef
    use64bitint=define, use64bitall=define, uselongdouble=undef
    usemymalloc=n, bincompat5005=undef
```
